### PR TITLE
fix: active images hidden by gallery CSS ordering

### DIFF
--- a/src/components/ImageGallery/styles.module.css
+++ b/src/components/ImageGallery/styles.module.css
@@ -19,7 +19,7 @@
   transition: opacity 0.35s ease;
 }
 
-.galleryImgActive {
+.galleryImg.galleryImgActive {
   opacity: 1;
 }
 


### PR DESCRIPTION
in the production build the minified css might get re-ordered so `.galleryImg { opacity: 0; }` might appear after `.galleryImgActive { opacity: 1; }` and the active image is hidden as well. so making the active rule more specific prevents this.