### PR TITLE
Update Conduit wallet link

### DIFF
--- a/src/pages/wallets.js
+++ b/src/pages/wallets.js
@@ -268,7 +268,7 @@ export default function Wallets() {
     {
       name: "Conduit",
       description: "Open source Fedimint wallet focused on Lightning, on-chain, and ecash payments. Built for simplicity and direct access to core Fedimint modules.",
-      link: "https://conduit.cash/",
+      link: "https://joschisan.github.io/conduit/",
       platforms: ["iOS", "Android"],
       modules: ["wallet", "mint", "ln-v2"],
       isBeta: false,


### PR DESCRIPTION
Conduit is now hosted at https://joschisan.github.io/conduit/ — updating the link on the wallets page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCHKgcRnbvzhsieFWYwF3x